### PR TITLE
chore: refactor provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,41 +123,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ferris-primitives"
-version = "0.1.0"
-dependencies = [
- "derive_more",
- "gloo-utils",
- "js-sys",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "tracing",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-bindgen-test",
- "web-sys",
-]
-
-[[package]]
-name = "ferris-wallet"
-version = "0.1.0"
-dependencies = [
- "chrome-sys",
- "gloo-utils",
- "js-sys",
- "jsonrpsee",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "tracing",
- "tracing-wasm",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +459,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
  "adler2",
+]
+
+[[package]]
+name = "nexum-primitives"
+version = "0.1.0"
+dependencies = [
+ "derive_more",
+ "gloo-utils",
+ "js-sys",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+ "web-sys",
 ]
 
 [[package]]
@@ -1065,11 +1047,11 @@ version = "0.1.0"
 dependencies = [
  "chrome-sys",
  "console_error_panic_hook",
- "ferris-primitives",
  "futures",
  "gloo-timers 0.3.0",
  "js-sys",
  "jsonrpsee",
+ "nexum-primitives",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",

--- a/crates/primitives/src/frame.rs
+++ b/crates/primitives/src/frame.rs
@@ -1,8 +1,51 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Debug, Default)]
+pub enum ConnectionState {
+    Connected,
+    #[default]
+    Disconnected,
+}
+
+impl ConnectionState {
+    pub fn is_disconnected(&self) -> bool {
+        matches!(self, ConnectionState::Disconnected)
+    }
+
+    pub fn is_connected(&self) -> bool {
+        matches!(self, ConnectionState::Connected)
+    }
+}
+
+impl Serialize for ConnectionState {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Serialize `Connected` as `true` and `Disconnected` as `false`
+        let as_bool = matches!(self, ConnectionState::Connected);
+        serializer.serialize_bool(as_bool)
+    }
+}
+
+impl<'de> Deserialize<'de> for ConnectionState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Deserialize `true` as `Connected` and `false` as `Disconnected`
+        let is_connected = bool::deserialize(deserializer)?;
+        Ok(if is_connected {
+            ConnectionState::Connected
+        } else {
+            ConnectionState::Disconnected
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct FrameState {
-    pub frame_connected: bool,
+    pub frame_connected: ConnectionState,
     pub available_chains: Vec<String>,
     pub current_chain: Option<u32>,
 }

--- a/crates/worker/src/events/runtime.rs
+++ b/crates/worker/src/events/runtime.rs
@@ -1,13 +1,13 @@
 use std::{cell::RefCell, future::Future, rc::Rc, sync::Arc};
 
 use chrome_sys::{port, tabs::send_message_to_tab};
-use nexum_primitives::{EthPayload, MessagePayload};
 use gloo_timers::callback::Timeout;
 use js_sys::{Function, Reflect};
 use jsonrpsee::{
     core::{client::ClientT, ClientError},
     wasm_client::Client,
 };
+use nexum_primitives::{EthPayload, MessagePayload};
 use serde::Deserialize;
 use serde_json::Value;
 use serde_wasm_bindgen::from_value;

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -1,10 +1,10 @@
 use std::sync::{Arc, RwLock};
 
 use builder::ExtensionBuilder;
-use chrome_sys::action::{self, IconPath, TabIconDetails};
 use events::setup_listeners;
 use futures::lock::Mutex;
 use js_sys::Reflect;
+use nexum_primitives::ConnectionState;
 use provider::{create_provider, monitor_provider, ProviderType};
 use state::ExtensionState;
 use tracing::{info, trace};
@@ -76,24 +76,6 @@ fn origin_from_url(url: Option<String>) -> String {
         }
         None => String::new(),
     }
-}
-
-enum ConnectionState {
-    Connected,
-    Disconnected,
-}
-
-/// Helper function to set the icon based on connection status
-fn set_icon_for_connection_state(state: ConnectionState) {
-    let path = match state {
-        ConnectionState::Connected => "icons/icon96good.png",
-        ConnectionState::Disconnected => "icons/icon96moon.png",
-    };
-    
-    let _ = action::set_icon(TabIconDetails {
-        path: Some(IconPath::Single(path.to_string())),
-        ..Default::default()
-    });
 }
 
 fn get_origin(sender: JsValue) -> String {

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, RwLock};
 
 use builder::ExtensionBuilder;
+use chrome_sys::action::{self, IconPath, TabIconDetails};
 use events::setup_listeners;
 use futures::lock::Mutex;
 use js_sys::Reflect;
@@ -75,6 +76,24 @@ fn origin_from_url(url: Option<String>) -> String {
         }
         None => String::new(),
     }
+}
+
+enum ConnectionState {
+    Connected,
+    Disconnected,
+}
+
+/// Helper function to set the icon based on connection status
+fn set_icon_for_connection_state(state: ConnectionState) {
+    let path = match state {
+        ConnectionState::Connected => "icons/icon96good.png",
+        ConnectionState::Disconnected => "icons/icon96moon.png",
+    };
+    
+    let _ = action::set_icon(TabIconDetails {
+        path: Some(IconPath::Single(path.to_string())),
+        ..Default::default()
+    });
 }
 
 fn get_origin(sender: JsValue) -> String {

--- a/crates/worker/src/provider.rs
+++ b/crates/worker/src/provider.rs
@@ -11,7 +11,7 @@ use tracing::{debug, trace, warn};
 use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::spawn_local;
 
-use crate::{events::send_event, set_icon_for_connection_state, ConnectionState, Extension};
+use crate::{events::send_event, ConnectionState, Extension};
 
 pub type ProviderType = Arc<RwLock<Option<Client>>>;
 const UPSTREAM_URL: &str = "ws://127.0.0.1:1248";
@@ -55,11 +55,9 @@ where
 async fn on_connect(extension: Arc<Extension>) {
     {
         let mut state = extension.state.lock().await;
-        state.set_frame_connected(true);
-        debug!("Provider connected");
+        state.set_frame_connected(ConnectionState::Connected);
     }
 
-    set_icon_for_connection_state(ConnectionState::Connected);
     send_event("connect", None, tabs::Query::default()).await;
     send_buffered_requests(extension).await;
 }
@@ -68,11 +66,9 @@ async fn on_connect(extension: Arc<Extension>) {
 async fn on_disconnect(extension: Arc<Extension>) {
     {
         let mut state = extension.state.lock().await;
-        state.set_frame_connected(false);
-        debug!("Provider disconnected");
+        state.set_frame_connected(ConnectionState::Disconnected);
     }
 
-    set_icon_for_connection_state(ConnectionState::Disconnected);
     send_event("disconnect", None, tabs::Query::default()).await;
 }
 

--- a/crates/worker/src/provider.rs
+++ b/crates/worker/src/provider.rs
@@ -11,47 +11,68 @@ use tracing::{debug, trace, warn};
 use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::spawn_local;
 
-use crate::{events::send_event, Extension};
+use crate::{events::send_event, set_icon_for_connection_state, ConnectionState, Extension};
 
 pub type ProviderType = Arc<RwLock<Option<Client>>>;
+const UPSTREAM_URL: &str = "ws://127.0.0.1:1248";
 
-/// Creates a new JSON-RPC client
-pub(crate) async fn create_provider() -> Result<Client, JsValue> {
-    let provider = WasmClientBuilder::default()
+/// Helper function to create a new JSON-RPC client
+pub async fn create_provider() -> Result<Client, JsValue> {
+    WasmClientBuilder::default()
         .request_timeout(Duration::from_secs(60))
-        .build("ws://127.0.0.1:1248")
-        .await;
+        .build(UPSTREAM_URL)
+        .await
+        .map_err(|e| JsValue::from_str(&format!("Failed to create provider: {:?}", e)))
+}
 
-    match provider {
-        Ok(client) => Ok(client),
-        Err(e) => Err(JsValue::from_str(&format!(
-            "Failed to create provider: {:?}",
-            e
-        ))),
+/// Helper function to access the client if connected
+fn with_connected_client<F>(provider: &ProviderType, action: F)
+where
+    F: FnOnce(&Client),
+{
+    if let Ok(provider_guard) = provider.read() {
+        if let Some(client) = provider_guard.as_ref() {
+            if client.is_connected() {
+                action(client);
+            }
+        }
     }
 }
 
-/// Executes logic needed when the provider connects
+/// Helper function to update provider with write lock
+fn with_write_lock<F>(provider: &Option<ProviderType>, action: F)
+where
+    F: FnOnce(&mut Option<Client>),
+{
+    if let Some(provider) = provider {
+        if let Ok(mut provider_guard) = provider.write() {
+            action(&mut *provider_guard);
+        }
+    }
+}
+
+/// Executes logic when the provider connects
 async fn on_connect(extension: Arc<Extension>) {
-    let mut state = extension.state.lock().await;
-    state.set_frame_connected(true);
-    debug!("Provider connected");
+    {
+        let mut state = extension.state.lock().await;
+        state.set_frame_connected(true);
+        debug!("Provider connected");
+    }
 
-    // Emit the "connect" event
-    drop(state); // Release lock on state before sending events
+    set_icon_for_connection_state(ConnectionState::Connected);
     send_event("connect", None, tabs::Query::default()).await;
-
-    // Send buffered RPC requests
     send_buffered_requests(extension).await;
 }
 
-/// Executes logic needed when the provider disconnects
+/// Executes logic when the provider disconnects
 async fn on_disconnect(extension: Arc<Extension>) {
-    let mut state = extension.state.lock().await;
-    state.set_frame_connected(false);
-    debug!("Provider disconnected");
+    {
+        let mut state = extension.state.lock().await;
+        state.set_frame_connected(false);
+        debug!("Provider disconnected");
+    }
 
-    // Emit the "disconnect" event
+    set_icon_for_connection_state(ConnectionState::Disconnected);
     send_event("disconnect", None, tabs::Query::default()).await;
 }
 
@@ -66,38 +87,23 @@ async fn send_buffered_requests(extension: Arc<Extension>) {
 
 /// Initializes the provider and starts monitoring its connection status
 pub(crate) async fn init_provider(extension: Arc<Extension>) {
-    // Early check: Read lock on provider to check if it's already initialized and connected
-    if let Some(provider) = extension.provider.as_ref() {
-        if let Ok(provider_guard) = provider.read() {
-            if let Some(client) = provider_guard.as_ref() {
-                if client.is_connected() {
-                    warn!("Provider already initialized and connected");
-                    return;
-                }
-            }
-        }
+    if let Some(provider) = &extension.provider {
+        with_connected_client(provider, |_| {
+            warn!("Provider already initialized and connected");
+        });
     }
 
-    // Attempt to initialize the provider
     match create_provider().await {
         Ok(client) => {
-            // Write lock to update provider after successful connection
-            if let Some(provider) = extension.provider.as_ref() {
-                if let Ok(mut provider_guard) = provider.write() {
-                    *provider_guard = Some(client);
-                }
-            }
-
-            // Execute the on-connect logic
+            with_write_lock(&extension.provider, |provider_guard| {
+                *provider_guard = Some(client);
+            });
             on_connect(extension.clone()).await;
         }
         Err(e) => {
-            // If building the client fails, set provider to None
-            if let Some(provider) = extension.provider.as_ref() {
-                if let Ok(mut provider_guard) = provider.write() {
-                    *provider_guard = None;
-                }
-            }
+            with_write_lock(&extension.provider, |provider_guard| {
+                *provider_guard = None;
+            });
             warn!(error = ?e, "Failed to initialize JSON-RPC client");
         }
     }
@@ -105,83 +111,59 @@ pub(crate) async fn init_provider(extension: Arc<Extension>) {
 
 /// Destroys the provider connection
 pub(crate) async fn destroy_provider(extension: Arc<Extension>) {
-    // Write lock to remove the provider if it exists
-    if let Some(provider) = extension.provider.as_ref() {
-        if let Ok(mut provider_guard) = provider.write() {
-            if provider_guard.take().is_some() {
-                debug!("Provider destroyed");
-            }
+    with_write_lock(&extension.provider, |provider_guard| {
+        if provider_guard.take().is_some() {
+            debug!("Provider destroyed");
         }
-    }
-
-    // Execute the on-disconnect logic
+    });
     on_disconnect(extension).await;
 }
 
 /// Monitors the provider's connection status, emitting disconnect and reconnect events as needed
 pub(crate) fn monitor_provider(provider: ProviderType, extension: Arc<Extension>) {
-    // Tracking whether the provider is disconnected and waiting for reconnection
     let disconnected = Arc::new(RwLock::new(false));
     let reconnecting = Arc::new(RwLock::new(false));
 
-    let monitor_interval = IntervalStream::new(5000);
-    let disconnected_clone = disconnected.clone();
-    let reconnecting_clone = reconnecting.clone();
-    let provider_clone = provider.clone();
-    let extension_clone = extension.clone();
-
     spawn_local(async move {
-        let mut interval = monitor_interval.fuse();
-        while let Some(_) = interval.next().await {
+        let mut interval = IntervalStream::new(5000).fuse();
+        while interval.next().await.is_some() {
             let is_disconnected = *disconnected.read().unwrap();
             let is_reconnecting = *reconnecting.read().unwrap();
 
-            if let Ok(provider_guard) = provider.read() {
-                if let Some(client) = provider_guard.as_ref() {
-                    if client.is_connected() {
-                        // Reset disconnected flag if connected
-                        if is_disconnected {
-                            *disconnected.write().unwrap() = false;
-                        }
-                        trace!("Monitor: Provider is connected");
-                        continue;
-                    }
-                }
+            with_connected_client(&provider, |_| {
+                *disconnected.write().unwrap() = false;
+                trace!("Monitor: Provider is connected");
+            });
+
+            // If the provider is connected, skip the rest of the loop iteration.
+            if !*disconnected.read().unwrap() {
+                continue;
             }
 
-            // If disconnected and not reconnecting, emit disconnect event and start reconnection
             if !is_disconnected && !is_reconnecting {
-                *disconnected_clone.write().unwrap() = true;
+                *disconnected.write().unwrap() = true;
                 debug!("Provider disconnected");
-
-                // Execute the on-disconnect logic
-                on_disconnect(extension_clone.clone()).await;
+                on_disconnect(extension.clone()).await;
             }
 
-            // If already reconnecting, skip further reconnection attempts
             if is_reconnecting {
                 continue;
             }
 
-            // Set reconnecting flag and attempt to reconnect
-            *reconnecting_clone.write().unwrap() = true;
+            *reconnecting.write().unwrap() = true;
             debug!("Attempting to reconnect provider...");
 
             match create_provider().await {
                 Ok(client) => {
-                    if let Ok(mut provider_guard) = provider_clone.write() {
+                    with_write_lock(&Some(provider.clone()), |provider_guard| {
                         *provider_guard = Some(client);
-                    }
-
-                    // Execute the on-connect logic
-                    on_connect(extension_clone.clone()).await;
-
-                    // Reset reconnecting flag
-                    *reconnecting_clone.write().unwrap() = false;
+                    });
+                    on_connect(extension.clone()).await;
+                    *reconnecting.write().unwrap() = false;
                 }
                 Err(e) => {
                     warn!(error = ?e, "Reconnection attempt failed");
-                    *reconnecting_clone.write().unwrap() = false; // Reset reconnecting on failure
+                    *reconnecting.write().unwrap() = false;
                 }
             }
         }


### PR DESCRIPTION
This PR:

1. Refactors the provider to reduce redundancy and ease maintenance burdens.
2. Makes use of a dedicated enum for holding connection state.