### PR TITLE
refactor: provider and builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +130,12 @@ dependencies = [
  "syn",
  "unicode-xid",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fnv"
@@ -1045,6 +1060,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 name = "worker"
 version = "0.1.0"
 dependencies = [
+ "async-lock",
  "chrome-sys",
  "console_error_panic_hook",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
+async-lock = "2.5"
 derive_more = { version = "1.0.0", default-features = false, features = ["display"] }
 wasm-bindgen = { version = "0.2.95", features = ["serde", "serde_json"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/primitives/src/message.rs
+++ b/crates/primitives/src/message.rs
@@ -13,7 +13,7 @@ pub struct MessagePayloadBase {
     jsonrpc: String,
     id: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
-    origin: Option<String>,
+    pub origin: Option<String>,
 }
 
 // EthEventPayload with Ethereum-specific event details

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -8,6 +8,7 @@ homepage.workspace = true
 exclude.workspace = true
 
 [dependencies]
+async-lock.workspace = true
 js-sys.workspace = true
 chrome-sys.workspace = true
 nexum-primitives.workspace = true

--- a/crates/worker/src/events/alarm.rs
+++ b/crates/worker/src/events/alarm.rs
@@ -1,42 +1,47 @@
 use chrome_sys::alarms;
-use jsonrpsee::core::client::ClientT;
 use serde_wasm_bindgen::from_value;
 use tracing::{error, info};
 use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::spawn_local;
 
-use crate::{provider::ProviderType, CLIENT_STATUS_ALARM_KEY};
+use crate::{Extension, CLIENT_STATUS_ALARM_KEY};
+use std::sync::Arc;
 
 // To be used with the `chrome.alarms.onAlarm` event
-pub async fn on_alarm(provider: ProviderType, alarm: JsValue) {
-    let alarm: alarms::AlarmInfo = from_value(alarm).unwrap();
+pub async fn on_alarm(extension: Arc<Extension>, alarm: JsValue) {
+    // Attempt to deserialize the alarm info and log an error if it fails
+    let alarm: alarms::AlarmInfo = match from_value(alarm) {
+        Ok(alarm) => alarm,
+        Err(e) => {
+            error!("Failed to parse alarm info: {:?}", e);
+            return;
+        }
+    };
 
     if alarm.name == CLIENT_STATUS_ALARM_KEY {
-        let provider_clone = provider.clone(); // Clone the Arc for use in spawn_local
-        spawn_local(async move {
-            match provider_clone.read() {
-                Ok(provider_guard) => {
-                    // Handle the read lock Result
-                    if let Some(client) = provider_guard.as_ref() {
-                        if client.is_connected() {
-                            match client
-                                .request::<String, _>("web3_clientVersion", Vec::<String>::new())
-                                .await
-                            {
-                                Ok(result) => {
-                                    info!("alarm keepalive web3_clientVersion result: {}", result);
-                                }
-                                Err(e) => {
-                                    error!("alarm RPC call failed: {:?}", e);
-                                }
-                            }
+        // Retrieve the provider from the extension
+        if let Some(provider) = &extension.provider {
+            let provider_clone = provider.clone();
+            spawn_local(async move {
+                // Use Provider's methods to handle connection checks
+                if provider_clone.is_connected().await {
+                    match provider_clone
+                        .request::<String>("web3_clientVersion", Vec::<String>::new())
+                        .await
+                    {
+                        Ok(result) => {
+                            info!("alarm keepalive web3_clientVersion result: {}", result);
+                        }
+                        Err(e) => {
+                            error!("alarm RPC call failed: {:?}", e);
                         }
                     }
+                } else {
+                    error!("Provider is not connected");
                 }
-                Err(e) => {
-                    error!("Failed to acquire read lock on provider: {:?}", e);
-                }
-            }
-        });
+            });
+        } else {
+            error!("Provider is not initialized in the extension");
+        }
     }
 }

--- a/crates/worker/src/events/idle.rs
+++ b/crates/worker/src/events/idle.rs
@@ -3,17 +3,18 @@ use std::sync::Arc;
 use tracing::debug;
 use wasm_bindgen::JsValue;
 
-use crate::{
-    provider::{destroy_provider, init_provider},
-    Extension,
-};
+use crate::Extension;
 
 // To be used with the `chrome.idle.onStateChanged` event
 pub async fn idle_on_state_changed(extension: Arc<Extension>, state: JsValue) {
     if state == "active" {
         debug!("Idle state changed to active");
-        let extension_clone = extension.clone();
-        destroy_provider(extension_clone).await;
-        init_provider(extension).await;
+
+        // Check if the provider exists and call reset
+        if let Some(provider) = &extension.provider {
+            provider.reset().await;
+        } else {
+            debug!("Provider is not initialized.");
+        }
     }
 }

--- a/crates/worker/src/events/runtime.rs
+++ b/crates/worker/src/events/runtime.rs
@@ -172,7 +172,8 @@ pub async fn runtime_on_message(extension: Arc<Extension>, message: JsValue, sen
                                     result: None,
                                     error: Some(Value::String("Request timed out".to_string())),
                                 };
-                                let message = MessagePayload::JsonResponse(eth_payload).to_js_value();
+                                let message =
+                                    MessagePayload::JsonResponse(eth_payload).to_js_value();
                                 if let Some(tab_id) = tab_id_from_sender(sender_clone) {
                                     if let Err(e) = send_message_to_tab(tab_id, message).await {
                                         warn!("Failed to send response to tab: {:?}", e);

--- a/crates/worker/src/events/runtime.rs
+++ b/crates/worker/src/events/runtime.rs
@@ -204,21 +204,12 @@ pub async fn runtime_on_message(
     }
 }
 
-async fn handle_request(client: &Client, p: &EthPayload) -> EthPayload {
-    match client
-        .request::<Value, _>(
-            &p.method.clone().unwrap_or_default(),
-            p.params.clone().unwrap_or_default(),
-        )
-        .await
-    {
-        Ok(response) => EthPayload {
-            base: p.base.clone(),
-            method: p.method.clone(),
-            params: p.params.clone(),
-            result: Some(response),
-            error: None,
-        },
+async fn handle_request(client: &Client, mut p: EthPayload) -> EthPayload {
+    let method = p.method.as_deref().unwrap_or_default();
+    let params = p.params.clone().unwrap_or_default(); // Clone the params if necessary
+
+    match client.request::<Value, _>(method, params).await {
+        Ok(response) => p.result = Some(response),
         Err(error) => {
             let error_message = match &error {
                 ClientError::Call(call_error) => {
@@ -235,16 +226,14 @@ async fn handle_request(client: &Client, p: &EthPayload) -> EthPayload {
                 }
             };
 
-            EthPayload {
-                base: p.base.clone(),
-                method: p.method.clone(),
-                params: p.params.clone(),
-                result: None,
-                error: Some(Value::String(error_message)),
-            }
+            p.error = Some(Value::String(error_message));
         }
     }
+
+    p
 }
+
+
 
 // Function to send the EthPayload message to the tab
 async fn send_response(sender: JsValue, eth_payload: EthPayload) {
@@ -267,12 +256,12 @@ fn create_request_task(
         let eth_payload = {
             let provider_guard = provider.read().expect("Failed to acquire read lock"); // Lock the provider (not async)
             if let Some(client) = provider_guard.as_ref() {
-                handle_request(client, &p).await
+                handle_request(client, p).await
             } else {
                 EthPayload {
-                    base: p.base.clone(),
-                    method: p.method.clone(),
-                    params: p.params.clone(),
+                    base: p.base,
+                    method: p.method,
+                    params: p.params,
                     result: None,
                     error: Some(Value::String("Client not available".to_string())),
                 }

--- a/crates/worker/src/events/runtime.rs
+++ b/crates/worker/src/events/runtime.rs
@@ -248,7 +248,7 @@ async fn send_response(sender: JsValue, eth_payload: EthPayload) {
 }
 
 fn create_request_task(
-    p: EthPayload,
+    mut p: EthPayload,
     provider: ProviderType,
     sender: JsValue,
 ) -> impl Future<Output = ()> {
@@ -258,13 +258,8 @@ fn create_request_task(
             if let Some(client) = provider_guard.as_ref() {
                 handle_request(client, p).await
             } else {
-                EthPayload {
-                    base: p.base,
-                    method: p.method,
-                    params: p.params,
-                    result: None,
-                    error: Some(Value::String("Client not available".to_string())),
-                }
+                p.error = Some(Value::String("Client not available".to_string()));
+                p
             }
         };
 

--- a/crates/worker/src/events/runtime.rs
+++ b/crates/worker/src/events/runtime.rs
@@ -3,10 +3,6 @@ use std::{cell::RefCell, future::Future, rc::Rc, sync::Arc};
 use chrome_sys::{port, tabs::send_message_to_tab};
 use gloo_timers::callback::Timeout;
 use js_sys::{Function, Reflect};
-use jsonrpsee::{
-    core::{client::ClientT, ClientError},
-    wasm_client::Client,
-};
 use nexum_primitives::{EthPayload, MessagePayload};
 use serde::Deserialize;
 use serde_json::Value;
@@ -15,11 +11,10 @@ use tracing::{debug, info, trace, warn};
 use wasm_bindgen::{prelude::Closure, JsCast, JsValue};
 use wasm_bindgen_futures::spawn_local;
 
-use crate::{provider::ProviderType, state::BufferedRequest, Extension, EXTENSION_PORT_NAME};
+use crate::{provider::Provider, state::BufferedRequest, Extension, EXTENSION_PORT_NAME};
 
 // To be used with the `chrome.runtime.onConnect` event
 pub async fn runtime_on_connect(extension: Arc<Extension>, js_port: JsValue) {
-    // Retrieve port name, logging on error
     trace!("Received connection: {:?}", js_port);
 
     #[derive(Deserialize)]
@@ -29,24 +24,21 @@ pub async fn runtime_on_connect(extension: Arc<Extension>, js_port: JsValue) {
 
     let port: Port = from_value(js_port.clone()).unwrap();
 
-    let extension_clone = extension.clone();
     if port.name == EXTENSION_PORT_NAME {
         trace!("Connection is for frame_connect");
-        let mut state = extension_clone.state.lock().await;
+        let mut state = extension.state.lock().await;
         state.settings_panel = Some(js_port.clone());
         state.update_settings_panel();
 
         // Add onDisconnect listener
-        port_on_disconnect(extension, js_port.clone());
+        port_on_disconnect(extension.clone(), js_port.clone());
     }
 }
 
 // Function to set up the on_disconnect handler
 fn port_on_disconnect(extension: Arc<Extension>, port: JsValue) {
-    // Create a placeholder for on_disconnect, initially set to None
     let on_disconnect: Rc<RefCell<Option<Closure<dyn Fn(JsValue)>>>> = Rc::new(RefCell::new(None));
 
-    // Clone references to port and on_disconnect to use in the closure
     let port_clone = port.clone();
     let on_disconnect_clone = Rc::clone(&on_disconnect);
 
@@ -55,11 +47,9 @@ fn port_on_disconnect(extension: Arc<Extension>, port: JsValue) {
         let on_disconnect_inner = on_disconnect_clone.clone();
         let extension_inner = extension.clone();
 
-        // Spawn a task to handle disconnection asynchronously
         spawn_local(async move {
             info!("Port disconnected");
 
-            // Access the singleton extension instance
             let mut state = extension_inner.state.lock().await;
             if state.settings_panel == Some(port_inner.clone()) {
                 debug!("Resetting settings_panel state");
@@ -67,7 +57,6 @@ fn port_on_disconnect(extension: Arc<Extension>, port: JsValue) {
                 state.update_settings_panel();
             }
 
-            // Remove the on_disconnect listener using the original closure
             if let Some(ref closure) = *on_disconnect_inner.borrow() {
                 if port::remove_on_disconnect_listener(
                     port_inner.clone(),
@@ -86,10 +75,8 @@ fn port_on_disconnect(extension: Arc<Extension>, port: JsValue) {
         });
     }) as Box<dyn Fn(JsValue)>);
 
-    // Populate the on_disconnect RefCell with the actual closure
     *on_disconnect.borrow_mut() = Some(on_disconnect_closure);
 
-    // Attach the on_disconnect handler to the port
     if let Some(ref closure) = *on_disconnect.borrow() {
         if let Err(e) =
             port::add_on_disconnect_listener(port.clone(), closure.as_ref().unchecked_ref())
@@ -98,17 +85,11 @@ fn port_on_disconnect(extension: Arc<Extension>, port: JsValue) {
         }
     }
 
-    // Keep the Rc alive
     let _ = Rc::clone(&on_disconnect);
 }
 
 // To be used with the `chrome.runtime.onMessage` event
-pub async fn runtime_on_message(
-    extension: Arc<Extension>,
-    provider: ProviderType,
-    message: JsValue,
-    sender: JsValue,
-) {
+pub async fn runtime_on_message(extension: Arc<Extension>, message: JsValue, sender: JsValue) {
     trace!("Received message: {:?} from {:?}", message, sender);
 
     let payload = match MessagePayload::from_js_value(&message) {
@@ -133,109 +114,109 @@ pub async fn runtime_on_message(
             warn!("Not implemented: handle ChainChanged payload - {:?}", p)
         }
         MessagePayload::JsonRequest(p) => {
-            // Guarantees:
-            // 1. Provider is connected
-            //      i. If provider is not connected, we buffer the request
-            //      ii. Once the provider is connected, we send the buffered requests
-            //      iii. Buffered requests are subject to the same timeout as configured
-            //           in jsonrpsee
-            // 2. Request timeout (handled by jsonrpsee)
-            //      i. If the request times out, we send an error response
-            //
-            // To handle this, we need to add a buffer to the extension state, and the buffer
-            // will consist of a series of closures that will be executed once the client is connected
-
-            let fut = create_request_task(p.clone(), provider.clone(), sender.clone());
-            if provider
-                .read()
-                .ok()
-                .and_then(|guard| guard.as_ref().map(|client| client.is_connected()))
-                .unwrap_or(false)
-            {
-                spawn_local(fut);
-            } else {
-                debug!("Provider is not connected, buffering request");
-                // At this point, we need to:
-                // 1. Generate a unique identifier for the request
-                // 2. Buffer the request
-                // 3. Create a timer after which we will send an error response
-
-                let uuid = uuid::Uuid::new_v4().to_string();
-
-                // Spawn a timer to handle the timeout
-                let extension_clone = extension.clone();
-                let sender_clone = sender.clone();
-                let uuid_clone = uuid.clone();
-                let timer = Timeout::new(60000, move || {
-                    spawn_local(async move {
-                        let mut state = extension_clone.state.lock().await;
-                        if let Some(_) = state.buffered_requests.remove(&uuid_clone) {
-                            debug!("Request timed out: {:?}", uuid_clone);
-                            let eth_payload = EthPayload {
-                                base: p.base,
-                                method: p.method,
-                                params: p.params,
-                                result: None,
-                                error: Some(serde_json::Value::String(
-                                    "Request timed out".to_string(),
-                                )),
-                            };
-                            let message = MessagePayload::JsonResponse(eth_payload).to_js_value();
-                            if let Some(tab_id) = tab_id_from_sender(sender_clone) {
-                                if let Err(e) = send_message_to_tab(tab_id, message).await {
-                                    warn!("Failed to send response to tab: {:?}", e);
+            if let Some(method) = &p.method {
+                match method.as_str() {
+                    "frame_summon" => {
+                        unimplemented!("handle frame_summon request - {:?}", p);
+                    }
+                    "embedded_action_res" => {
+                        if let Some(params) = &p.params {
+                            if let (Some(action), Some(res)) = (params.get(0), params.get(1)) {
+                                if action.get("type")
+                                    == Some(&Value::String("getChainId".to_string()))
+                                {
+                                    if let Some(chain_id_value) = res.get("chainId") {
+                                        if let Some(chain_id_str) = chain_id_value.as_str() {
+                                            if let Ok(chain_id) = chain_id_str.parse::<u32>() {
+                                                extension
+                                                    .state
+                                                    .lock()
+                                                    .await
+                                                    .set_current_chain(chain_id);
+                                                return;
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }
-                    });
-                });
+                        warn!("Failed to handle embedded_action_res: {:?}", p);
+                        return;
+                    }
+                    _ => {}
+                }
+            }
 
-                // Buffer the request
-                let mut state = extension.state.lock().await;
-                state.buffered_requests.insert(
-                    uuid,
-                    BufferedRequest {
-                        timer,
-                        future: Box::pin(fut),
-                    },
-                );
+            // Use the provider within the extension to create the request task
+            if let Some(provider) = extension.provider.as_ref() {
+                let fut = create_request_task(p.clone(), provider.clone(), sender.clone());
+                if provider.is_connected().await {
+                    spawn_local(fut);
+                } else {
+                    debug!("Provider is not connected, buffering request");
+
+                    let uuid = uuid::Uuid::new_v4().to_string();
+                    let extension_clone = extension.clone();
+                    let sender_clone = sender.clone();
+                    let uuid_clone = uuid.clone();
+
+                    let timer = Timeout::new(60000, move || {
+                        spawn_local(async move {
+                            let mut state = extension_clone.state.lock().await;
+                            if let Some(_) = state.buffered_requests.remove(&uuid_clone) {
+                                debug!("Request timed out: {:?}", uuid_clone);
+                                let eth_payload = EthPayload {
+                                    base: p.base,
+                                    method: p.method,
+                                    params: p.params,
+                                    result: None,
+                                    error: Some(Value::String("Request timed out".to_string())),
+                                };
+                                let message = MessagePayload::JsonResponse(eth_payload).to_js_value();
+                                if let Some(tab_id) = tab_id_from_sender(sender_clone) {
+                                    if let Err(e) = send_message_to_tab(tab_id, message).await {
+                                        warn!("Failed to send response to tab: {:?}", e);
+                                    }
+                                }
+                            }
+                        });
+                    });
+
+                    let mut state = extension.state.lock().await;
+                    state.buffered_requests.insert(
+                        uuid,
+                        BufferedRequest {
+                            timer,
+                            future: Box::pin(fut),
+                        },
+                    );
+                }
+            } else {
+                warn!("Provider not initialized.");
             }
         }
     }
 }
 
-async fn handle_request(client: &Client, mut p: EthPayload) -> EthPayload {
-    let method = p.method.as_deref().unwrap_or_default();
-    let params = p.params.clone().unwrap_or_default(); // Clone the params if necessary
+fn create_request_task(
+    mut p: EthPayload,
+    provider: Arc<Provider>,
+    sender: JsValue,
+) -> impl Future<Output = ()> {
+    async move {
+        warn!("Origin upstreaming not implemented: {:?}", p.base.origin);
 
-    match client.request::<Value, _>(method, params).await {
-        Ok(response) => p.result = Some(response),
-        Err(error) => {
-            let error_message = match &error {
-                ClientError::Call(call_error) => {
-                    trace!("Call error: {:?}", call_error);
-                    serde_json::to_string(call_error).unwrap()
-                }
-                ClientError::Transport(transport_error) => {
-                    trace!("Transport error: {:?}", transport_error);
-                    serde_json::to_string(&transport_error.to_string()).unwrap()
-                }
-                _ => {
-                    trace!("Other error: {:?}", error);
-                    serde_json::to_string(&error.to_string()).unwrap()
-                }
-            };
+        let method = p.method.clone().unwrap_or_default();
+        let params = p.params.clone().unwrap_or_default();
+        match provider.request::<Value>(&method, params).await {
+            Ok(response) => p.result = Some(response),
+            Err(_) => p.error = Some(Value::String("Client not available".to_string())),
+        };
 
-            p.error = Some(Value::String(error_message));
-        }
+        send_response(sender, p).await;
     }
-
-    p
 }
 
-
-
-// Function to send the EthPayload message to the tab
 async fn send_response(sender: JsValue, eth_payload: EthPayload) {
     let message = MessagePayload::JsonResponse(eth_payload).to_js_value();
     trace!("Sending response: {:?}", message);
@@ -244,26 +225,6 @@ async fn send_response(sender: JsValue, eth_payload: EthPayload) {
         if let Err(e) = send_message_to_tab(tab_id, message).await {
             warn!("Failed to send response to tab {}: {:?}", tab_id, e);
         }
-    }
-}
-
-fn create_request_task(
-    mut p: EthPayload,
-    provider: ProviderType,
-    sender: JsValue,
-) -> impl Future<Output = ()> {
-    async move {
-        let eth_payload = {
-            let provider_guard = provider.read().expect("Failed to acquire read lock"); // Lock the provider (not async)
-            if let Some(client) = provider_guard.as_ref() {
-                handle_request(client, p).await
-            } else {
-                p.error = Some(Value::String("Client not available".to_string()));
-                p
-            }
-        };
-
-        send_response(sender, eth_payload).await;
     }
 }
 

--- a/crates/worker/src/provider.rs
+++ b/crates/worker/src/provider.rs
@@ -1,167 +1,276 @@
-use std::{
-    sync::{Arc, RwLock},
-    time::Duration,
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
 };
+use std::time::Duration;
 
+use async_lock::RwLock;
 use chrome_sys::tabs;
-use futures::StreamExt;
-use gloo_timers::future::IntervalStream;
-use jsonrpsee::wasm_client::{Client, WasmClientBuilder};
+use futures::{
+    future::{select, Either},
+    StreamExt,
+};
+use gloo_timers::future::{IntervalStream, TimeoutFuture};
+use jsonrpsee::{
+    core::{client::ClientT, traits::ToRpcParams},
+    wasm_client::{Client, WasmClientBuilder},
+};
 use tracing::{debug, trace, warn};
 use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::spawn_local;
 
 use crate::{events::send_event, ConnectionState, Extension};
 
-pub type ProviderType = Arc<RwLock<Option<Client>>>;
 const UPSTREAM_URL: &str = "ws://127.0.0.1:1248";
 
-/// Helper function to create a new JSON-RPC client
-pub async fn create_provider() -> Result<Client, JsValue> {
+pub struct Provider {
+    client: RwLock<Option<Client>>,
+    disconnected: AtomicBool,
+    reconnecting: AtomicBool,
+    extension: Arc<Extension>,
+}
+
+impl Provider {
+    pub fn new(extension: Arc<Extension>) -> Arc<Self> {
+        Arc::new(Self {
+            client: RwLock::new(None),
+            disconnected: AtomicBool::new(true),
+            reconnecting: AtomicBool::new(false),
+            extension,
+        })
+    }
+
+    /// Initialize the provider and start monitoring its connection
+    pub async fn init(self: &Arc<Self>) {
+        match create_client().await {
+            Ok(client) => {
+                self.set_client(Some(client)).await;
+                if self.disconnected.swap(false, Ordering::Relaxed) && self.verify_connection().await {
+                    self.clone().on_connect().await;
+                } else {
+                    self.clear_client().await;
+                    // Ensure `disconnected` is set to `true` after clearing client,
+                    // but do not emit "disconnect" on initial failure if already disconnected.
+                    if !self.disconnected.load(Ordering::Relaxed) {
+                        self.disconnected.store(true, Ordering::Relaxed);
+                    }
+                }
+            }
+            Err(e) => {
+                self.clear_client().await;
+                self.disconnected.store(true, Ordering::Relaxed);
+                warn!(error = ?e, "Failed to initialize JSON-RPC client");
+            }
+        }
+        self.start_monitoring();
+    }
+
+    /// Reset the provider state, used when coming out of idle
+    pub async fn reset(self: &Arc<Self>) {
+        debug!("Resetting provider state");
+        self.clone().destroy().await;
+        self.init().await;
+    }
+
+    /// Destroy the provider, disconnecting the client
+    async fn destroy(self: Arc<Self>) {
+        self.clear_client().await;
+        self.on_disconnect().await;
+    }
+
+    /// Set the client instance
+    async fn set_client(&self, client: Option<Client>) {
+        let mut guard = self.client.write().await;
+        *guard = client;
+    }
+
+    /// Clear the client instance
+    async fn clear_client(&self) {
+        let mut guard = self.client.write().await;
+        *guard = None;
+    }
+
+    /// Check if the provider client is currently connected
+    pub async fn is_connected(&self) -> bool {
+        let guard = self.client.read().await;
+        if let Some(client) = &*guard {
+            client.is_connected()
+        } else {
+            false
+        }
+    }
+
+    /// Executes logic when the provider connects
+    async fn on_connect(self: Arc<Self>) {
+        {
+            let mut state = self.extension.state.lock().await;
+            state.set_frame_connected(ConnectionState::Connected);
+        }
+
+        send_event("connect", None, tabs::Query::default()).await;
+        self.send_buffered_requests().await;
+    }
+
+    /// Executes logic when the provider disconnects
+    async fn on_disconnect(self: Arc<Self>) {
+        {
+            let mut state = self.extension.state.lock().await;
+            state.set_frame_connected(ConnectionState::Disconnected);
+        }
+
+        send_event("disconnect", None, tabs::Query::default()).await;
+    }
+
+    /// Helper function to verify the connection by making a lightweight RPC call
+    async fn verify_connection(&self) -> bool {
+        let guard = self.client.read().await;
+        if let Some(client) = &*guard {
+            client
+                .request::<String, _>("eth_chainId", &[] as &[String])
+                .await
+                .is_ok()
+        } else {
+            false
+        }
+    }
+
+    /// Sends all buffered RPC requests
+    async fn send_buffered_requests(&self) {
+        let mut state = self.extension.state.lock().await;
+        state.buffered_requests.drain().for_each(|req| {
+            debug!("Flushing buffered request: {:?}", req.0);
+            spawn_local(req.1.future);
+        });
+    }
+
+    /// Starts monitoring the provider connection status
+    fn start_monitoring(self: &Arc<Self>) {
+        let provider_clone = self.clone();
+        spawn_local(async move {
+            let mut interval = IntervalStream::new(5000).fuse();
+            while interval.next().await.is_some() {
+                if !Provider::check_and_reconnect(provider_clone.clone()).await {
+                    break;
+                }
+            }
+        });
+    }
+
+    /// Checks connection status and attempts reconnection if disconnected
+    async fn check_and_reconnect(provider: Arc<Self>) -> bool {
+        trace!("Monitor: checking provider connection status");
+
+        if !provider.disconnected.load(Ordering::Relaxed) && provider.is_connected().await {
+            if provider.disconnected.swap(false, Ordering::Relaxed) {
+                trace!("Monitor: provider reconnected, running on_connect");
+
+                let provider_clone = provider.clone();
+                spawn_local(async move {
+                    provider_clone.on_connect().await;
+                });
+            }
+            return true;
+        }
+
+        provider.clone().handle_disconnection().await;
+        provider.attempt_reconnect().await
+    }
+
+    /// Handles provider disconnection without consuming self
+    async fn handle_disconnection(self: Arc<Self>) {
+        if !self.disconnected.swap(true, Ordering::Relaxed) {
+            trace!("Monitor: provider disconnected, running on_disconnect");
+
+            let provider_clone = self.clone();
+            spawn_local(async move {
+                provider_clone.on_disconnect().await;
+            });
+        }
+    }
+
+    /// Attempts to reconnect the provider without consuming self
+    async fn attempt_reconnect(self: Arc<Self>) -> bool {
+        if !self.disconnected.load(Ordering::Relaxed) || self.reconnecting.load(Ordering::Relaxed) {
+            return true;
+        }
+
+        self.reconnecting.store(true, Ordering::Relaxed);
+        trace!("Monitor: attempting to reconnect provider...");
+
+        let provider_clone = self.clone();
+        spawn_local(async move {
+            let timeout = TimeoutFuture::new(30_000);
+            let reconnect_attempt = Box::pin(create_client());
+
+            match select(timeout, reconnect_attempt).await {
+                Either::Left(_) => {
+                    trace!("Monitor: reconnection attempt timed out");
+                    provider_clone.reconnecting.store(false, Ordering::Relaxed);
+                }
+                Either::Right((result, _)) => match result {
+                    Ok(client) => {
+                        provider_clone.set_client(Some(client)).await;
+                        if provider_clone.verify_connection().await {
+                            trace!("Monitor: reconnection attempt successful");
+                            provider_clone.clone().finalize_reconnection();
+                        }
+                        provider_clone.reconnecting.store(false, Ordering::Relaxed);
+                    }
+                    Err(e) => {
+                        trace!(?e, "Monitor: reconnection attempt failed");
+                        provider_clone.reconnecting.store(false, Ordering::Relaxed);
+                    }
+                },
+            }
+        });
+
+        true
+    }
+
+    /// Finalizes the reconnection process by setting connection state and triggering on_connect without consuming self
+    fn finalize_reconnection(self: Arc<Self>) {
+        if !self.disconnected.load(Ordering::Relaxed) {
+            return;
+        }
+        self.disconnected.store(false, Ordering::Relaxed);
+        let provider_clone = self.clone();
+        spawn_local(async move {
+            provider_clone.on_connect().await;
+        });
+    }
+
+    /// Generalized request function to send an RPC request through the client
+    pub async fn request<T: serde::de::DeserializeOwned>(
+        &self,
+        method: &str,
+        params: impl ToRpcParams + Send,
+    ) -> Result<T, JsValue> {
+        trace!("Provider::request: method={}", method);
+        // Acquire a read lock on the client
+        let client_guard = self.client.read().await;
+
+        // Check if the client is available and connected
+        if let Some(client) = client_guard.as_ref() {
+            if client.is_connected() {
+                // Perform the request and handle any errors
+                client
+                    .request::<T, _>(method, params)
+                    .await
+                    .map_err(|e| JsValue::from_str(&format!("Request failed: {:?}", e)))
+            } else {
+                Err(JsValue::from_str("Client is not connected"))
+            }
+        } else {
+            Err(JsValue::from_str("Client is not available"))
+        }
+    }
+}
+
+/// Creates a new JSON-RPC client with a timeout of 60 seconds
+async fn create_client() -> Result<Client, JsValue> {
     WasmClientBuilder::default()
         .request_timeout(Duration::from_secs(60))
         .build(UPSTREAM_URL)
         .await
         .map_err(|e| JsValue::from_str(&format!("Failed to create provider: {:?}", e)))
-}
-
-/// Helper function to access the client if connected
-fn with_connected_client<F>(provider: &ProviderType, action: F)
-where
-    F: FnOnce(&Client),
-{
-    if let Ok(provider_guard) = provider.read() {
-        if let Some(client) = provider_guard.as_ref() {
-            if client.is_connected() {
-                action(client);
-            }
-        }
-    }
-}
-
-/// Helper function to update provider with write lock
-fn with_write_lock<F>(provider: &Option<ProviderType>, action: F)
-where
-    F: FnOnce(&mut Option<Client>),
-{
-    if let Some(provider) = provider {
-        if let Ok(mut provider_guard) = provider.write() {
-            action(&mut *provider_guard);
-        }
-    }
-}
-
-/// Executes logic when the provider connects
-async fn on_connect(extension: Arc<Extension>) {
-    {
-        let mut state = extension.state.lock().await;
-        state.set_frame_connected(ConnectionState::Connected);
-    }
-
-    send_event("connect", None, tabs::Query::default()).await;
-    send_buffered_requests(extension).await;
-}
-
-/// Executes logic when the provider disconnects
-async fn on_disconnect(extension: Arc<Extension>) {
-    {
-        let mut state = extension.state.lock().await;
-        state.set_frame_connected(ConnectionState::Disconnected);
-    }
-
-    send_event("disconnect", None, tabs::Query::default()).await;
-}
-
-/// Sends all buffered RPC requests
-async fn send_buffered_requests(extension: Arc<Extension>) {
-    let mut state = extension.state.lock().await;
-    state.buffered_requests.drain().for_each(|req| {
-        debug!("Flushing buffered request: {:?}", req.0);
-        spawn_local(req.1.future);
-    });
-}
-
-/// Initializes the provider and starts monitoring its connection status
-pub(crate) async fn init_provider(extension: Arc<Extension>) {
-    if let Some(provider) = &extension.provider {
-        with_connected_client(provider, |_| {
-            warn!("Provider already initialized and connected");
-        });
-    }
-
-    match create_provider().await {
-        Ok(client) => {
-            with_write_lock(&extension.provider, |provider_guard| {
-                *provider_guard = Some(client);
-            });
-            on_connect(extension.clone()).await;
-        }
-        Err(e) => {
-            with_write_lock(&extension.provider, |provider_guard| {
-                *provider_guard = None;
-            });
-            warn!(error = ?e, "Failed to initialize JSON-RPC client");
-        }
-    }
-}
-
-/// Destroys the provider connection
-pub(crate) async fn destroy_provider(extension: Arc<Extension>) {
-    with_write_lock(&extension.provider, |provider_guard| {
-        if provider_guard.take().is_some() {
-            debug!("Provider destroyed");
-        }
-    });
-    on_disconnect(extension).await;
-}
-
-/// Monitors the provider's connection status, emitting disconnect and reconnect events as needed
-pub(crate) fn monitor_provider(provider: ProviderType, extension: Arc<Extension>) {
-    let disconnected = Arc::new(RwLock::new(false));
-    let reconnecting = Arc::new(RwLock::new(false));
-
-    spawn_local(async move {
-        let mut interval = IntervalStream::new(5000).fuse();
-        while interval.next().await.is_some() {
-            let is_disconnected = *disconnected.read().unwrap();
-            let is_reconnecting = *reconnecting.read().unwrap();
-
-            with_connected_client(&provider, |_| {
-                *disconnected.write().unwrap() = false;
-                trace!("Monitor: Provider is connected");
-            });
-
-            // If the provider is connected, skip the rest of the loop iteration.
-            if !*disconnected.read().unwrap() {
-                continue;
-            }
-
-            if !is_disconnected && !is_reconnecting {
-                *disconnected.write().unwrap() = true;
-                debug!("Provider disconnected");
-                on_disconnect(extension.clone()).await;
-            }
-
-            if is_reconnecting {
-                continue;
-            }
-
-            *reconnecting.write().unwrap() = true;
-            debug!("Attempting to reconnect provider...");
-
-            match create_provider().await {
-                Ok(client) => {
-                    with_write_lock(&Some(provider.clone()), |provider_guard| {
-                        *provider_guard = Some(client);
-                    });
-                    on_connect(extension.clone()).await;
-                    *reconnecting.write().unwrap() = false;
-                }
-                Err(e) => {
-                    warn!(error = ?e, "Reconnection attempt failed");
-                    *reconnecting.write().unwrap() = false;
-                }
-            }
-        }
-    });
 }

--- a/crates/worker/src/provider.rs
+++ b/crates/worker/src/provider.rs
@@ -45,7 +45,9 @@ impl Provider {
         match create_client().await {
             Ok(client) => {
                 self.set_client(Some(client)).await;
-                if self.disconnected.swap(false, Ordering::Relaxed) && self.verify_connection().await {
+                if self.disconnected.swap(false, Ordering::Relaxed)
+                    && self.verify_connection().await
+                {
                     self.clone().on_connect().await;
                 } else {
                     self.clear_client().await;

--- a/crates/worker/src/state.rs
+++ b/crates/worker/src/state.rs
@@ -37,6 +37,10 @@ pub(crate) struct BufferedRequest {
 }
 
 impl ExtensionState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     pub fn update_settings_panel(&self) {
         if let Some(panel) = &self.settings_panel {
             debug!("Updating settings panel with new frame state");


### PR DESCRIPTION
This PR:

1. Refactored `crates/worker` module to streamline `Extension` and `Provider` components, improving structure, error handling, and logging. Key updates:

   - **Builder Refactor:** Revised `ExtensionBuilder` to use `Arc<Provider>` and `Arc<Mutex<ExtensionState>>`, enhancing provider initialization and robustness.
   - **Error Handling:** Improved error logging for `on_alarm` and refined `idle_on_state_changed` to check for provider existence.
   - **Code Simplification:** Removed `ProviderType`, updated event listeners to use `Arc<Extension>`, and streamlined `runtime` event handlers.
   - **Dependencies:** Added `async-lock` to workspace dependencies.
   - **Struct Changes:** Made `origin` field in `MessagePayloadBase` public.