### PR TITLE
chore: use cargo binstall for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,9 +5,12 @@
         "ghcr.io/devcontainers/features/rust:1": {
             "version": "latest"
         },
+	"ghcr.io/lee-orr/rusty-dev-containers/cargo-binstall:0": {
+	    "packages": "trunk,leptosfmt,wasm-pack,wasm-opt"
+	},
         "ghcr.io/nlordell/features/foundry": {}
     },
-    "postCreateCommand": "sudo DEBIAN_FRONTEND=noninteractive apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config libssl-dev clang && cargo install trunk leptosfmt wasm-pack wasm-opt",
+    "postCreateCommand": "sudo DEBIAN_FRONTEND=noninteractive apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config libssl-dev clang",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,8 @@
         "ghcr.io/devcontainers/features/rust:1": {
             "version": "latest"
         },
-	"ghcr.io/lee-orr/rusty-dev-containers/cargo-binstall:0": {
-	    "packages": "trunk,leptosfmt,wasm-pack,wasm-opt"
+        "ghcr.io/lee-orr/rusty-dev-containers/cargo-binstall:0": {
+            "packages": "trunk,leptosfmt,wasm-pack,wasm-opt"
 	},
         "ghcr.io/nlordell/features/foundry": {}
     },


### PR DESCRIPTION
This PR:

1. Makes use of `cargo-binstall` instead of compiling package requirements from scratch, greatly reducing devcontainer build time.