### PR TITLE
chore: tui -> nexum-tui, rpc -> nexum-rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4536,6 +4536,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "nexum-rpc"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "alloy-chains 0.1.47",
+ "clap",
+ "eyre",
+ "futures",
+ "hyper",
+ "jsonrpsee",
+ "paste",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tower 0.5.2",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "nexum-tui"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "alloy-chains 0.1.47",
+ "clap",
+ "crossterm",
+ "eyre",
+ "figment",
+ "futures",
+ "nexum-rpc",
+ "ratatui",
+ "serde",
+ "thiserror 2.0.12",
+ "tokio",
+ "toml",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5698,28 +5742,6 @@ name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
-
-[[package]]
-name = "rpc"
-version = "0.1.0"
-dependencies = [
- "alloy",
- "alloy-chains 0.1.47",
- "clap",
- "eyre",
- "futures",
- "hyper",
- "jsonrpsee",
- "paste",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
- "tokio",
- "tower 0.5.2",
- "tracing",
- "tracing-subscriber",
- "url",
-]
 
 [[package]]
 name = "rstml"
@@ -7236,28 +7258,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tui"
-version = "0.1.0"
-dependencies = [
- "alloy",
- "alloy-chains 0.1.47",
- "clap",
- "crossterm",
- "eyre",
- "figment",
- "futures",
- "ratatui",
- "rpc",
- "serde",
- "thiserror 2.0.12",
- "tokio",
- "toml",
- "tracing",
- "tracing-subscriber",
- "url",
-]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ worker = { path = "crates/nexum/extension/worker" }
 injected = { path = "crates/nexum/extension/injected" }
 injector = { path = "crates/nexum/extension/injector"}
 nexum-primitives = { path = "crates/nexum/primitives" }
-rpc = { path = "crates/nexum/rpc" }
+nexum-rpc = { path = "crates/nexum/rpc" }
 
 # Common
 thiserror = { version = "2.0", default-features = false }

--- a/crates/nexum/rpc/Cargo.toml
+++ b/crates/nexum/rpc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rpc"
+name = "nexum-rpc"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/nexum/rpc/src/bin/rpc.rs
+++ b/crates/nexum/rpc/src/bin/rpc.rs
@@ -3,7 +3,7 @@ use std::net::Ipv4Addr;
 use alloy_chains::NamedChain;
 use clap::Parser;
 use eyre::OptionExt;
-use rpc::rpc::{chain_id_or_name_to_named_chain, RpcServerBuilder};
+use nexum_rpc::rpc::{chain_id_or_name_to_named_chain, RpcServerBuilder};
 use url::Url;
 
 #[derive(Parser, Debug)]

--- a/crates/nexum/tui/Cargo.toml
+++ b/crates/nexum/tui/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tui"
+name = "nexum-tui"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -17,7 +17,7 @@ crossterm = { version = "0.29.0", features = ["event-stream"] }
 futures.workspace = true
 alloy.workspace = true
 clap.workspace = true
-rpc.workspace = true
+nexum-rpc.workspace = true
 eyre.workspace = true
 figment = { version = "0.10.19", features = ["toml"] }
 serde.workspace = true

--- a/crates/nexum/tui/src/main.rs
+++ b/crates/nexum/tui/src/main.rs
@@ -19,6 +19,9 @@ use clap::Parser;
 use config_tab::ConfigTab;
 use crossterm::event::{Event, EventStream, KeyCode, KeyEvent};
 use futures::StreamExt;
+use nexum_rpc::rpc::{
+    chain_id_or_name_to_named_chain, InteractiveRequest, InteractiveResponse, RpcServerBuilder,
+};
 use ratatui::{
     layout::{Constraint, HorizontalAlignment, Layout},
     prelude::{Buffer, Rect},
@@ -29,9 +32,6 @@ use ratatui::{
         Block, Borders, FrameExt, List, ListState, Padding, Paragraph, StatefulWidget, Tabs, Widget,
     },
     DefaultTerminal, Frame,
-};
-use rpc::rpc::{
-    chain_id_or_name_to_named_chain, InteractiveRequest, InteractiveResponse, RpcServerBuilder,
 };
 use signers::{load_foundry_keystores, load_ledger_accounts, NexumAccount};
 use tokio::sync::{mpsc, oneshot};


### PR DESCRIPTION
Rename `rpc` and `tui` crates to `nexum-rpc` and `nexum-tui` respectively.