### PR TITLE
fix: use GitHub App for CLA Assistant authentication

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -8,7 +8,7 @@ on:
 # explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
 permissions:
   actions: write
-  contents: write # this can be 'read' if the signatures are in remote repository
+  contents: read # read-only since signatures are stored in remote repository
   pull-requests: write
   statuses: write
 
@@ -16,12 +16,21 @@ jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CLA_APP_ID }}
+          private-key: ${{ secrets.CLA_APP_PRIVATE_KEY }}
+          owner: nxm-rs
+          repositories: "nexum,cla-signatures"
+
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           path-to-signatures: 'nexum/cla.json'
           path-to-document: 'https://github.com/nxm-rs/nexum/blob/main/CLA.md'


### PR DESCRIPTION
**AI Assistance Disclosure**: This PR was created with assistance from Claude Code.

---

## Description

Fixes CLA Assistant 401 authentication errors by switching from Personal Access Token to GitHub App authentication.

## Changes

- Add `actions/create-github-app-token@v2` step to generate short-lived app token
- Update CLA Assistant to use app token instead of PAT
- Reduce `contents` permission from `write` to `read`

## Issue

Fixes #82 CLA check failures

---

**Setup Required:** GitHub App must be created with `CLA_APP_ID` and `CLA_APP_PRIVATE_KEY` secrets configured. See CONTRIBUTING.md for details.