### PR TITLE
feat(tui): add zero-config startup with ephemeral wallet and prank mode

### DIFF
--- a/crates/nexum/extension/worker/src/provider.rs
+++ b/crates/nexum/extension/worker/src/provider.rs
@@ -21,7 +21,7 @@ use wasm_bindgen_futures::spawn_local;
 
 use crate::{ConnectionState, Extension, events::send_event};
 
-const UPSTREAM_URL: &str = "ws://127.0.0.1:1250/sepolia";
+const UPSTREAM_URL: &str = "ws://127.0.0.1:1250/mainnet";
 
 pub struct Provider {
     client: RwLock<Option<Client>>,

--- a/crates/nexum/primitives/src/protocol.rs
+++ b/crates/nexum/primitives/src/protocol.rs
@@ -1,5 +1,6 @@
 use derive_more::Display;
 use gloo_utils::format::JsValueSerdeExt;
+use js_sys::Reflect;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::JsValue;
 
@@ -74,6 +75,17 @@ impl ProtocolMessage {
     }
 
     pub fn is_valid(js_value: &JsValue) -> bool {
+        // Quick check: must be an object with protocol="nexum" before attempting deserialize
+        if !js_value.is_object() {
+            return false;
+        }
+        let Ok(protocol) = Reflect::get(js_value, &JsValue::from_str("protocol")) else {
+            return false;
+        };
+        if protocol.as_string().as_deref() != Some("nexum") {
+            return false;
+        }
+        // Now safe to attempt full deserialization
         js_value.into_serde::<ProtocolMessage>().is_ok()
     }
 }

--- a/crates/nexum/rpc/src/bin/rpc.rs
+++ b/crates/nexum/rpc/src/bin/rpc.rs
@@ -9,7 +9,7 @@ use url::Url;
 #[derive(Parser, Debug)]
 #[command(about)]
 pub struct Args {
-    #[arg(short, long, default_value = "127.0.0.1")]
+    #[arg(short = 'H', long, default_value = "127.0.0.1")]
     pub host: Ipv4Addr,
 
     #[arg(short, long, default_value = "1248")]

--- a/crates/nexum/tui/src/config.rs
+++ b/crates/nexum/tui/src/config.rs
@@ -56,23 +56,27 @@ impl Default for Config {
         Self {
             rpcs: BTreeMap::from([
                 (
-                    "mainnet".to_string(),
+                    "Mainnet".to_string(),
                     "https://eth.llamarpc.com".parse().unwrap(),
                 ),
                 (
-                    "gnosis".to_string(),
+                    "Gnosis".to_string(),
                     "https://rpc.gnosischain.com".parse().unwrap(),
                 ),
                 (
-                    "sepolia".to_string(),
-                    "https://ethereum-sepolia-rpc.publicnode.com".parse().unwrap(),
+                    "Sepolia".to_string(),
+                    "https://ethereum-sepolia-rpc.publicnode.com"
+                        .parse()
+                        .unwrap(),
                 ),
                 (
-                    "holesky".to_string(),
-                    "https://ethereum-holesky-rpc.publicnode.com".parse().unwrap(),
+                    "Holesky".to_string(),
+                    "https://ethereum-holesky-rpc.publicnode.com"
+                        .parse()
+                        .unwrap(),
                 ),
                 (
-                    "hoodi".to_string(),
+                    "Hoodi".to_string(),
                     "https://rpc.hoodi.ethpandaops.io".parse().unwrap(),
                 ),
             ]),
@@ -94,11 +98,7 @@ impl Config {
                     .parse::<NamedChain>()
                     .map(|chain| (chain, url.clone()))
                     .inspect_err(|e| {
-                        tracing::warn!(
-                            chain_name,
-                            ?e,
-                            "failed to parse chain name, skipping"
-                        );
+                        tracing::warn!(chain_name, ?e, "failed to parse chain name, skipping");
                     })
                     .ok()
             })

--- a/crates/nexum/tui/src/config.rs
+++ b/crates/nexum/tui/src/config.rs
@@ -3,11 +3,7 @@ use std::{
     path::PathBuf,
 };
 
-use alloy::{
-    network::Ethereum,
-    primitives::Address,
-    providers::{Provider, RootProvider},
-};
+use alloy::primitives::Address;
 use alloy_chains::NamedChain;
 use eyre::OptionExt;
 use figment::{
@@ -55,28 +51,58 @@ impl Default for LedgerConfig {
     }
 }
 
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            rpcs: BTreeMap::from([
+                (
+                    "mainnet".to_string(),
+                    "https://eth.llamarpc.com".parse().unwrap(),
+                ),
+                (
+                    "gnosis".to_string(),
+                    "https://rpc.gnosischain.com".parse().unwrap(),
+                ),
+                (
+                    "sepolia".to_string(),
+                    "https://ethereum-sepolia-rpc.publicnode.com".parse().unwrap(),
+                ),
+                (
+                    "holesky".to_string(),
+                    "https://ethereum-holesky-rpc.publicnode.com".parse().unwrap(),
+                ),
+                (
+                    "hoodi".to_string(),
+                    "https://rpc.hoodi.ethpandaops.io".parse().unwrap(),
+                ),
+            ]),
+            origin_connections: BTreeMap::new(),
+            labels: BTreeMap::new(),
+            signer: SignerConfig::default(),
+        }
+    }
+}
+
 impl Config {
-    pub async fn chain_rpcs(&self) -> eyre::Result<Vec<(NamedChain, Url)>> {
-        let providers = futures::future::join_all(self.rpcs.values().map(|rpc_url| {
-            let rpc_url = rpc_url.to_string();
-            async move { RootProvider::<Ethereum>::connect(&rpc_url).await }
-        }))
-        .await
-        .into_iter()
-        .collect::<Result<Vec<_>, _>>()?;
-        let chain_ids = futures::future::join_all(providers.iter().map(|p| p.get_chain_id()))
-            .await
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()?;
-        let chains = chain_ids
-            .into_iter()
-            .map(NamedChain::try_from)
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| eyre::eyre!("failed to parse chainid to NamedChain: {e:?}"))?;
-        Ok(chains
-            .into_iter()
-            .zip(self.rpcs.values().cloned())
-            .collect())
+    /// Returns chain RPCs parsed from config keys (no network validation).
+    /// Invalid chain names are skipped with a warning.
+    pub fn chain_rpcs(&self) -> Vec<(NamedChain, Url)> {
+        self.rpcs
+            .iter()
+            .filter_map(|(chain_name, url)| {
+                chain_name
+                    .parse::<NamedChain>()
+                    .map(|chain| (chain, url.clone()))
+                    .inspect_err(|e| {
+                        tracing::warn!(
+                            chain_name,
+                            ?e,
+                            "failed to parse chain name, skipping"
+                        );
+                    })
+                    .ok()
+            })
+            .collect()
     }
 
     pub fn keystores(&self) -> eyre::Result<Vec<NexumAccount>> {
@@ -107,8 +133,14 @@ pub fn config_dir() -> eyre::Result<PathBuf> {
     Ok(dir)
 }
 
-pub fn load_config() -> eyre::Result<Config> {
-    Ok(Figment::new()
-        .merge(Toml::file(config_dir()?.join("nxm.toml")))
-        .extract()?)
+pub fn load_config() -> Config {
+    config_dir()
+        .ok()
+        .and_then(|dir| {
+            Figment::new()
+                .merge(Toml::file(dir.join("nxm.toml")))
+                .extract()
+                .ok()
+        })
+        .unwrap_or_default()
 }


### PR DESCRIPTION
## What

This PR enhances the TUI to work out-of-the-box without requiring configuration:

1. **Default RPC endpoints** - Adds mainnet, gnosis, sepolia, holesky, and hoodi RPCs so the TUI starts without `~/.nxm/nxm.toml`
2. **Ephemeral wallet** - Creates a random in-memory wallet on startup (not persisted to disk)
3. **Prank mode** - New `--prank <ADDRESS>` flag to report a nominated address for `eth_requestAccounts` without having the private key (Foundry-style terminology)
4. **Non-blocking startup** - Changed `chain_rpcs()` to parse chain names synchronously instead of connecting to validate

Additional fixes included:
- Optimized `ProtocolMessage::is_valid()` with early return checks
- Fixed `-h` short arg conflict in RPC binary (changed to `-H`)
- Changed extension upstream RPC to mainnet

## Why

The TUI previously required manual configuration before first use. This creates friction for:
- Quick testing and development
- Users who want to try the extension without setting up keystores
- Testing dapp integrations with a specific address (prank mode)

## Testing

- Ran `cargo clippy -p nexum-tui -p nexum-rpc -- -Dwarnings` - passes with no warnings
- Ran `cargo build -p nexum-tui` - builds successfully
- Tested TUI startup without config file - starts with default RPCs and ephemeral wallet
- Tested `--prank 0x...` flag - reports nominated address, signing prompts appear but fail as expected
- Verified `--help` output shows new `--prank` option

## AI Assistance

AI Assistance: Claude Code used for implementation of all changes, code review, and PR description.