### PR TITLE
fix(ci): add checks:write permission to audit workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,6 +18,7 @@ on:
 permissions:
   contents: read
   issues: write
+  checks: write
 
 jobs:
   audit:


### PR DESCRIPTION
## What does this PR do?
Fixes the Security Audit workflow failure by adding the missing `checks: write` permission required by `rustsec/audit-check@v2`.

## Changes
- Added `checks: write` permission to `.github/workflows/audit.yml`

## Breaking changes
None.

## Testing
- [ ] Unit tests pass (N/A - workflow change only)
- [x] Manual testing completed (workflow will run on this PR)
- [ ] Documentation updated (if needed) (N/A)

## Related issues
Fixes the failed workflow run: https://github.com/nxm-rs/nexum/actions/runs/20554091497

The error was:
```
Resource not accessible by integration - https://docs.github.com/rest/checks/runs#create-a-check-run
```

## AI assistance disclosure
Claude Code was used to investigate the failed workflow run and implement this fix.

## Notes for reviewers
The `rustsec/audit-check@v2` action creates GitHub check runs to report audit results. Without `checks: write` permission, this fails with a 403 error. The audit itself completed successfully (no vulnerabilities found, 2 unmaintained crate warnings for `derivative` and `paste`).

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [ ] Tests added/updated (N/A)
- [x] No console.logs or debug code left behind
- [x] PR title is descriptive