### PR TITLE
chore: replace paste with pastey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,7 +813,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -824,7 +824,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2661,7 +2661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4682,7 +4682,7 @@ dependencies = [
  "futures",
  "hyper",
  "jsonrpsee",
- "paste",
+ "pastey",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -4757,7 +4757,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4989,6 +4989,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pathdiff"
@@ -6051,7 +6057,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6931,7 +6937,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8103,7 +8109,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/audit.toml
+++ b/audit.toml
@@ -1,0 +1,5 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2024-0436", # paste is used by multiple dependencies
+    "RUSTSEC-2024-0388", # derivative is used by ark-ff(dependency of ruint)
+]

--- a/crates/nexum/rpc/Cargo.toml
+++ b/crates/nexum/rpc/Cargo.toml
@@ -23,5 +23,5 @@ eyre.workspace = true
 url.workspace = true
 alloy-chains.workspace = true
 alloy.workspace = true
-paste = "1.0.15"
+pastey = "0.2.1"
 thiserror.workspace = true

--- a/crates/nexum/rpc/src/namespaces/mod.rs
+++ b/crates/nexum/rpc/src/namespaces/mod.rs
@@ -6,7 +6,7 @@ pub mod web3;
 #[macro_export]
 macro_rules! upstream_request {
     ($method_name:literal) => {
-        paste::paste! {
+        pastey::paste! {
         #[allow(non_snake_case)]
         async fn [<upstream_ $method_name>]<F, P> (
             params: jsonrpsee::types::Params<'static>,
@@ -50,7 +50,7 @@ macro_rules! upstream_requests {
     ($rpc_module:ident, $($method_name:literal),+) => {
         $(
             $crate::upstream_request!($method_name);
-            paste::paste! {
+            pastey::paste! {
             $rpc_module.register_async_method($method_name, [<upstream_ $method_name>])?;
             }
         )+


### PR DESCRIPTION
## What does this PR do?
<!-- One sentence. What problem does this solve? -->
Replace unmaintained `paste` with `pastey`, also add the unmaintained advisory for `derivative` and `paste` to audit.toml ignored.