### PR TITLE
feat(rpc): implement personal_sign with TUI prompt + fix chain name parsing

### DIFF
--- a/crates/nexum/rpc/src/rpc.rs
+++ b/crates/nexum/rpc/src/rpc.rs
@@ -101,6 +101,7 @@ pub enum InteractiveRequest {
     SignTransaction(Box<EthereumTypedTransaction<TxEip4844Variant>>),
     EthSign(Address, Bytes),
     EthSignTypedData(Address, Box<TypedData>),
+    PersonalSign(Address, Bytes),
 }
 
 /// Responses for the interactive requests
@@ -111,6 +112,7 @@ pub enum InteractiveResponse {
     SignTransaction(Result<Signature, Box<dyn std::error::Error + Send + Sync>>),
     EthSign(Result<Signature, Box<dyn std::error::Error + Send + Sync>>),
     EthSignTypedData(Result<Signature, Box<dyn std::error::Error + Send + Sync>>),
+    PersonalSign(Result<Signature, Box<dyn std::error::Error + Send + Sync>>),
 }
 
 pub async fn make_interactive_request(

--- a/crates/nexum/rpc/src/rpc.rs
+++ b/crates/nexum/rpc/src/rpc.rs
@@ -181,13 +181,18 @@ impl RpcServerBuilder {
 }
 
 pub fn chain_id_or_name_to_named_chain(chain: &str) -> eyre::Result<NamedChain> {
-    let chain = chain.parse::<NamedChain>().map(Some).unwrap_or_else(|_| {
-        chain
-            .parse::<u64>()
-            .map(|chainid| NamedChain::try_from(chainid).ok())
-            .ok()
-            .flatten()
-    });
+    // NamedChain uses strum's kebab-case serialization, so convert to lowercase for name matching
+    let chain = chain
+        .to_lowercase()
+        .parse::<NamedChain>()
+        .map(Some)
+        .unwrap_or_else(|_| {
+            chain
+                .parse::<u64>()
+                .map(|chainid| NamedChain::try_from(chainid).ok())
+                .ok()
+                .flatten()
+        });
     chain.ok_or_eyre("failed to parse chain")
 }
 

--- a/crates/nexum/tui/src/config.rs
+++ b/crates/nexum/tui/src/config.rs
@@ -94,7 +94,9 @@ impl Config {
         self.rpcs
             .iter()
             .filter_map(|(chain_name, url)| {
+                // NamedChain uses strum's kebab-case serialization, so convert to lowercase
                 chain_name
+                    .to_lowercase()
                     .parse::<NamedChain>()
                     .map(|chain| (chain, url.clone()))
                     .inspect_err(|e| {


### PR DESCRIPTION
## Summary

This PR adds two improvements to the TUI/RPC:

1. **Fix case-insensitive chain name parsing** - Chain names in config (e.g., "Mainnet", "Gnosis") were failing to parse because `NamedChain` expects kebab-case lowercase names. Now converts to lowercase before parsing.

2. **Implement `personal_sign` RPC method** - Adds support for the `personal_sign` JSON-RPC method commonly used by dapps. Includes a TUI prompt dialog for user approval.

## What

### Chain name parsing fix
- `Config::chain_rpcs()` now converts chain names to lowercase before parsing
- `chain_id_or_name_to_named_chain()` also converts to lowercase for consistency
- Numeric chain IDs continue to work as before

### personal_sign implementation
- Added `PersonalSign` variants to `InteractiveRequest`/`InteractiveResponse`
- Registered `personal_sign` RPC method with reversed parameter order `(message, address)` per the standard
- Added TUI prompt dialog with Accept/Reject controls
- Message displayed as UTF-8 when decodable, hex otherwise

## Why

- Chain name parsing was broken for all default config chain names, causing warnings on startup
- `personal_sign` is a commonly used RPC method that many dapps rely on for message signing

## Testing

- Verified chain names parse correctly after fix (no more `VariantNotFound` warnings)
- Built and ran clippy with no warnings
- Ran test suite

## AI Assistance

AI assistance (Claude) was used for code generation and implementation of both features.