### PR TITLE
docs: introduce runtime layer in top-level documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Nexum is a high-performance Ethereum provider written in Rust and compiled to We
 
 ### High-Level Structure
 
-Nexum is organized into three main layers:
+Nexum is organised into four main layers:
 
 1. **APDU Layer** (`crates/apdu/`) - Smart card communication protocol
    - `core`: Foundation types (ApduCommand, ApduResponse, CardTransport, Executor)
@@ -36,6 +36,8 @@ Nexum is organized into three main layers:
    - `rpc`: JSON-RPC server with namespaces (eth, net, wallet, web3)
    - `tui`: Terminal interface with ratatui
    - `extension`: Five WASM components for browser integration
+
+4. **Runtime Layer** (`crates/nexum/runtime/`) — WASM Component Model host that loads guest modules conforming to the `web3:runtime` WIT package. Exposes universal host interfaces (consensus, local store, remote store, messaging, logging) so guest modules are portable across host environments.
 
 ### Browser Extension Architecture
 
@@ -78,6 +80,12 @@ just run-ext
 
 # Package extension for distribution
 just pack-ext
+
+# Build the WASM runtime host
+cargo build -p nexum-runtime
+
+# Build an example guest module (wasm32-wasip2)
+cargo build --target wasm32-wasip2 -p nexum-runtime-example
 ```
 
 ### Testing
@@ -119,6 +127,9 @@ cargo run -p nexum-rpc -- --host 127.0.0.1 --port 1248
 
 # Run Keycard CLI
 cargo run -p keycard-cli -- --help
+
+# Run the runtime host against a guest WASM module
+cargo run -p nexum-runtime -- path/to/guest.wasm
 ```
 
 ---
@@ -272,3 +283,7 @@ For detailed information about specific components, see:
 - Extension worker: `crates/nexum/extension/worker/src/`
 - Shared types: `crates/nexum/primitives/src/`
 - TUI: `crates/nexum/tui/src/main.rs`
+- Runtime host: `crates/nexum/runtime/src/main.rs`
+- WIT interfaces: `wit/web3-runtime/`
+- Example guest module: `modules/example/src/lib.rs`
+- Runtime design docs: `docs/runtime/`

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Nexum is an Ethereum provider written in Rust and compiled to WebAssembly, built
 
 Nexum combines **WebTransport** with a **terminal-based** interface: ideal for developers seeking a flexible, performant tool to interact with Ethereum across web and terminal environments.
 
+Nexum also ships a **WASM Component Model runtime** for portable Ethereum automation modules. Guest modules are written against the universal `web3:runtime` WIT package, which defines abstract host interfaces for consensus access, local and decentralised storage, pub/sub messaging, and structured logging. Because every host capability is expressed as WIT, the same guest module runs unchanged across native, mobile, and browser hosts that implement these interfaces. See [docs/runtime/](./docs/runtime/) for the full design.
+
 ## Goals
 
 1. **Compliance**: Full [`EIP-1193`](https://eips.ethereum.org/EIPS/eip-1193) and [`EIP-6963`](https://eips.ethereum.org/EIPS/eip-6963) compliance.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@ This document provides a comprehensive overview of Nexum's architecture, compone
 
 ## Overview
 
-Nexum is a high-performance Ethereum provider written in Rust and compiled to WebAssembly. It provides both a browser extension and a terminal-based interface (TUI) for interacting with Ethereum networks. The codebase is organized into multiple focused crates that handle different concerns: APDU smart card operations, Keycard integration, core RPC functionality, and extension components.
+Nexum is a high-performance Ethereum provider written in Rust and compiled to WebAssembly. It provides both a browser extension and a terminal-based interface (TUI) for interacting with Ethereum networks. The codebase is organised into multiple focused crates that handle different concerns: APDU smart card operations, Keycard integration, core RPC functionality, extension components, and a WASM Component Model runtime for portable guest modules.
 
 **Key Technologies:**
 - Language: Rust
@@ -36,12 +36,19 @@ nexum/
 │       ├── primitives/             # Shared types and protocols (WASM)
 │       ├── rpc/                    # JSON-RPC server and namespaces
 │       ├── tui/                    # Terminal user interface (ratatui)
+│       ├── runtime/                # WASM Component Model host (guest modules)
 │       └── extension/              # Browser extension components
 │           ├── chrome-sys/         # Chrome API bindings (WASM)
 │           ├── worker/             # Service worker (WASM)
 │           ├── injector/           # Content script injector (WASM)
 │           ├── injected/           # Injected frame script (WASM)
 │           └── browser-ui/         # Extension popup UI (Leptos/WASM)
+│
+├── wit/
+│   └── web3-runtime/               # Universal WIT interfaces for guest modules
+│
+└── modules/
+    └── example/                    # Example headless guest module
 ```
 
 **Default members for `cargo build`:** `rpc` and `tui` (the CLI applications)
@@ -164,6 +171,33 @@ nexum/
   - `signers`: Account management (Ledger support via `load_ledger_accounts()`)
   - Response channel: Sends `InteractiveResponse` back to RPC server for request fulfillment
   - Logging to file (`nxm.log`) via custom writer
+
+### 4. Runtime Layer (`crates/nexum/runtime/`)
+
+**Purpose:** Host-side WASM Component Model runtime that loads guest modules conforming to the `web3:runtime` WIT package and exposes a set of universal, host-environment-agnostic interfaces. The runtime allows third parties to ship portable Ethereum automation modules (watchers, indexers, agents) that run unchanged across native, mobile, and browser hosts, as long as the host implements the same WIT interfaces.
+
+#### Universal WIT Interfaces (`wit/web3-runtime/`)
+
+The `web3:runtime` package defines the abstract surface guests can rely on:
+
+- `csn` — JSON-RPC consensus access for chain reads (blocks, receipts, logs, state)
+- `local-store` — keyed local persistence scoped to the guest module
+- `remote-store` — content-addressed decentralised storage (Swarm/IPFS-style)
+- `msg` — pub/sub messaging over a Waku-style transport
+- `logging` — structured logs routed through the host's tracing infrastructure
+- `types` — shared event and configuration types used across the other interfaces
+- `headless-module` — the main guest world, which exports `init` and `on_event`
+
+#### Guest Module Lifecycle
+
+1. The host instantiates the component from a WASM binary and links the host implementations of each imported interface.
+2. The host calls `init(config)` once, passing a serialised configuration payload so the guest can establish state and subscriptions.
+3. The host feeds subsequent events into `on_event(event)` — block headers, messages, timers, and other host-originated notifications.
+4. Guests interact with the outside world exclusively through the imported WIT interfaces, so the host controls all I/O, persistence, and network access.
+
+Because all host capabilities are expressed as WIT interfaces, this layer is deliberately host-environment-agnostic: the same guest binaries can run against alternative host implementations (mobile, browser, server) without changes.
+
+See [docs/runtime/](./runtime/) for full design documentation.
 
 ---
 
@@ -492,3 +526,7 @@ wasm-pack build -t web --release crates/nexum/extension/injected
 - **Type Definitions:** Look in `crates/nexum/primitives/src/`
 - **UI Components:** Navigate `crates/nexum/extension/browser-ui/src/`
 - **Manifest & Build:** Check `crates/nexum/extension/public/manifest.json`
+- **Runtime Host:** Start at `crates/nexum/runtime/src/main.rs`
+- **WIT Interfaces:** Browse `wit/web3-runtime/`
+- **Example Module:** See `modules/example/src/lib.rs`
+- **Runtime Design Docs:** Read [docs/runtime/](./runtime/)


### PR DESCRIPTION
## Summary

- **`docs/ARCHITECTURE.md`** — adds a new "Runtime Layer" section after the Nexum Core layer, describing the WASM Component Model host (`crates/nexum/runtime/`), the universal `web3:runtime` WIT interfaces (`csn`, `local-store`, `remote-store`, `msg`, `logging`, `types`, `headless-module`), the guest lifecycle (`init` then `on_event`), and the host-environment-agnostic design rationale. Extends the workspace tree diagram to show `crates/nexum/runtime/`, `wit/web3-runtime/`, and `modules/example/`. Adds runtime-related entries to the Quick Navigation list.
- **`CLAUDE.md`** — bumps "three main layers" to "four main layers" and adds the runtime as the fourth bullet. Adds the new build/run commands (`cargo build -p nexum-runtime`, `cargo build --target wasm32-wasip2 -p nexum-runtime-example`, `cargo run -p nexum-runtime -- path/to/guest.wasm`). Adds runtime locations to the Key source locations list.
- **`README.md`** — adds a single short paragraph introducing the runtime to users, linking to `docs/runtime/` for the full design.

This is part of the runtime migration tracked on the `runtime` branch (merging the WASM Component Model runtime + universal WIT interfaces from the shepherd repo). Other PRs add the actual crates, WIT files, in-depth design docs, build tooling, and Nix devshell support.

Oxford English style is preserved throughout. The links to `crates/nexum/runtime/` and `docs/runtime/` will resolve once the sibling PRs land on `runtime`.

## Test plan

- [x] Render `docs/ARCHITECTURE.md` and verify the new section reads cleanly and matches the surrounding tone
- [x] Verify the workspace tree diagram in ARCHITECTURE.md is accurate
- [x] Check that `CLAUDE.md` still parses as Claude project instructions
- [x] Verify Oxford English consistency

## AI assistance disclosure

This PR was prepared with AI assistance (Claude Code): the documentation edits were drafted by an automated agent following an approved migration plan, and this PR description was AI-drafted. Content was verified against the conventions documented in CLAUDE.md.
