### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -24,8 +24,8 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
-      - uses: rustsec/audit-check@v2
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998  # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -24,7 +24,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998  # v2.0.0
         with:

--- a/.github/workflows/extension.yaml
+++ b/.github/workflows/extension.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Checkout code
 
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
@@ -22,7 +22,7 @@ jobs:
           targets: wasm32-unknown-unknown,x86_64-unknown-linux-gnu
           components: clippy,rustfmt
 
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: |
             ~/.cargo/bin/
@@ -57,7 +57,7 @@ jobs:
         run: just be
 
       - name: Upload firefox extension
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: firefox-extension
           path: crates/nexum/extension/dist/

--- a/.github/workflows/extension.yaml
+++ b/.github/workflows/extension.yaml
@@ -13,16 +13,16 @@ jobs:
     steps:
       - name: Checkout code
 
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
         with:
           toolchain: nightly-2026-04-07
           targets: wasm32-unknown-unknown,x86_64-unknown-linux-gnu
           components: clippy,rustfmt
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: |
             ~/.cargo/bin/
@@ -57,7 +57,7 @@ jobs:
         run: just be
 
       - name: Upload firefox extension
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: firefox-extension
           path: crates/nexum/extension/dist/


### PR DESCRIPTION
## Summary

Pin every third-party GitHub Actions reference in this repos workflows to a 40-character commit SHA, with the original ref preserved as a trailing comment. This defends CI against tag-supply-chain attacks where a compromised maintainer pushes a malicious commit and re-points an existing tag (as in the [tj-actions/changed-files March 2025 incident](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised)).

## Pinned actions

- actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
- actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
- actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
- dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
- rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998  # v2.0.0

## Out of scope

- `cla.yml` (`contributor-assistant/github-action`, `actions/create-github-app-token`) - handled in a separate PR.
- First-party `nxm-rs/*` actions / reusable workflows - none currently referenced.

## References

- https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised
- https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

## Test plan

- [ ] CI passes on this branch (all jobs still run as before, just from immutable SHAs).
- [ ] Spot-check one workflow file diff: ref hash matches `git ls-remote` for the listed tag.